### PR TITLE
deletes semicolons that sometimes appear at the end of "ORG:" names

### DIFF
--- a/src/Vcard/Parser.php
+++ b/src/Vcard/Parser.php
@@ -208,6 +208,8 @@ class Parser implements \IteratorAggregate
                         $cardData->version = $value;
                         break;
                     case 'ORG':
+                        if (substr($value, -1) == ';')    //  deletes semicolons that sometimes appear at the end
+                            $value = substr($value, 0, -1);
                         $cardData->organization = $value;
                         break;
                     case 'URL':


### PR DESCRIPTION
Semicolon are already included in the download data