### PR TITLE
Solves issue #32:

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This is an entirely simplified version of https://github.com/jens-maus/carddav2f
   * upload of contact pictures to display them on the FRITZ!Fon (handling see below)
   * transfer of quick dial and vanity numbers (see wiki for handling details)
   * if more than nine phone numbers are included, the contact will be divided into a corresponding number of phonebook entries (any existing email addresses are assigned to the first set [there is no quantity limit!])
+  * phone numbers are sorted by type. The order of the conversion values ('phoneTypes') determines the order in the phone book entry
   * the contact's UID of the CardDAV server is added to the phonebook entry (not visible in the FRITZ! Box GUI)
 
 ## Requirements

--- a/config.example.php
+++ b/config.example.php
@@ -3,7 +3,7 @@
 $config = [
 	// phonebook
 	'phonebook' => [
-		'id'        => 0,                 // only '0' can store images
+		'id'        => 0,                                              // only "0" can store quickdial and vanity numbers
 		'name'      => 'Telefonbuch',
         'imagepath' => 'file:///var/InternerSpeicher/[YOURUSBSTICK]/FRITZ/fonpix/', // mandatory if you use the -i option
 	],
@@ -57,7 +57,10 @@ $config = [
 				'PERS'
 			],
 		],
-	'realName' => [
+        /**
+		 * 'realName' conversions are processed consecutively. Order decides!
+		 */
+	    'realName' => [
 			'{lastname}, {prefix} {nickname}',
 			'{lastname}, {prefix} {firstname}',
 			'{lastname}, {nickname}',
@@ -65,6 +68,10 @@ $config = [
 			'{organization}',
 			'{fullname}'
 		],
+		/**
+		 * 'phoneTypes':
+		 * The order of the target values (first occurrence) determines the sorting of the telephone numbers
+		 */
 		'phoneTypes' => [
 			'WORK' => 'work',
 			'HOME' => 'home',
@@ -74,8 +81,11 @@ $config = [
 			'WORK' => 'work',
 			'HOME' => 'home'
 		],
+		/**
+		 * 'phoneReplaceCharacters' conversions are processed consecutively. Order decides!
+		 */
 		'phoneReplaceCharacters' => [
-			'+49' => '',  //Router steht default in DE; '0049' könnte auch Teil einer Rufnummer sein
+			'+49' => '',  // router is usually operated in 'DE; '0049' could also be part of a phone number
             '('   => '',
 			')'   => '',
 			'/'   => '',

--- a/src/FritzBox/Converter.php
+++ b/src/FritzBox/Converter.php
@@ -19,7 +19,7 @@ class Converter
     {
         $this->config    = $config['conversions'];
         $this->imagePath = $config['phonebook']['imagepath'] ?? NULL;
-        $this->phoneSort = $this->getSortingData();
+        $this->phoneSort = $this->getNumberSequence();
     }
 
     public function convert($card)
@@ -61,13 +61,11 @@ class Converter
      * returns a simple array depending on the order of phonetype conversions
      * whose order should determine the sorting of the telephone numbers
      */
-    private function getSortingData()
+    private function getNumberSequence()
     {
-        foreach ($this->config['phoneTypes'] as $idx => $value) {
-            $sortArr[] = strtolower($value);
-        }
-        $sortArr[] = 'other';                          // ensures that the default value is included
-        return array_unique($sortArr);                 // deletes duplicates
+        $seqArr = array_values(array_map('strtolower', $this->config['phoneTypes']));
+        $seqArr[] = 'other';                               // ensures that the default value is included
+        return array_unique($seqArr);                      // deletes duplicates
     }
 
     private function addVip()
@@ -196,13 +194,9 @@ class Converter
             usort($phoneNumbers, function($a, $b) use ($ordering) {
                 $idx1 = array_search($a['type'], $ordering, true);
                 $idx2 = array_search($b['type'], $ordering, true);
-                if($idx1 == $idx2)
-                    if($a['number'] > $b['number'])
-                       return 1;
-                    else
-                       return -1;
-                    //return 0;      value before implementation of second query
-                elseif($idx1 < $idx2)
+                if ($idx1 == $idx2)
+                    return ($a['number'] > $b['number']) ? 1 : -1;
+                elseif ($idx1 < $idx2)
                     return -1;
                 return 1;
             });

--- a/src/FritzBox/Converter.php
+++ b/src/FritzBox/Converter.php
@@ -190,15 +190,13 @@ class Converter
             }
         }
         if (count($phoneNumbers) > 1) {
-            $ordering = $this->phoneSort;
-            usort($phoneNumbers, function($a, $b) use ($ordering) {
-                $idx1 = array_search($a['type'], $ordering, true);
-                $idx2 = array_search($b['type'], $ordering, true);
+            usort($phoneNumbers, function($a, $b) {
+                $idx1 = array_search($a['type'], $this->phoneSort, true);
+                $idx2 = array_search($b['type'], $this->phoneSort, true);
                 if ($idx1 == $idx2)
                     return ($a['number'] > $b['number']) ? 1 : -1;
-                elseif ($idx1 < $idx2)
-                    return -1;
-                return 1;
+                else
+                    return ($idx1 < $idx2) ? -1 : +1;
             });
         }
         return $phoneNumbers;

--- a/src/FritzBox/Converter.php
+++ b/src/FritzBox/Converter.php
@@ -19,7 +19,7 @@ class Converter
     {
         $this->config    = $config['conversions'];
         $this->imagePath = $config['phonebook']['imagepath'] ?? NULL;
-        $this->phoneSort = $this->getNumberSequence();
+        $this->phoneSort = $this->getPhoneTypesSortOrder();
     }
 
     public function convert($card)
@@ -61,7 +61,7 @@ class Converter
      * returns a simple array depending on the order of phonetype conversions
      * whose order should determine the sorting of the telephone numbers
      */
-    private function getNumberSequence()
+    private function getPhoneTypesSortOrder()
     {
         $seqArr = array_values(array_map('strtolower', $this->config['phoneTypes']));
         $seqArr[] = 'other';                               // ensures that the default value is included
@@ -196,7 +196,7 @@ class Converter
                 if ($idx1 == $idx2)
                     return ($a['number'] > $b['number']) ? 1 : -1;
                 else
-                    return ($idx1 < $idx2) ? -1 : +1;
+                    return ($idx1 > $idx2) ? 1 : -1;
             });
         }
         return $phoneNumbers;


### PR DESCRIPTION
Phone numbers are sorted by type. The order of the conversion target values (first occurence) determines the order in the phone book entry. If the type is equal the numbers are sorted ascending