### PR TITLE
Disable certificate verification for Fritz!Boxes

### DIFF
--- a/src/FritzBox/Api.php
+++ b/src/FritzBox/Api.php
@@ -55,6 +55,8 @@ class Api
             curl_setopt($ch, CURLOPT_URL, $this->url . '/cgi-bin/webcm');
         }
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+	curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
+	curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
         curl_setopt($ch, CURLOPT_POST, 1);
         curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($formfields));
         $output = curl_exec($ch);
@@ -75,6 +77,8 @@ class Api
         }
         curl_setopt($ch, CURLOPT_URL, $this->url . '/cgi-bin/firmwarecfg');
         curl_setopt($ch, CURLOPT_POST, 1);
+	curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
+	curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
 
         // enable for debugging:
         //curl_setopt($ch, CURLOPT_VERBOSE, TRUE);
@@ -188,7 +192,11 @@ class Api
 
         $url = $this->url . $getpage . http_build_query($params);
 
-        $this->client = $this->client ?? new Client();
+        $this->client = $this->client ?? new Client(
+	 array(
+	  'verify' => false
+	  )
+        );
         $response = $this->client->send(new Request('GET', $url));
 
         if (200 !== $response->getStatusCode()) {


### PR DESCRIPTION
Basically, all FritzBox's using self-signed certificates if you're enable HTTPS.

Edit: Wrong issue reference.