### PR TITLE
Contacts without a phone number and only with an e-mail address

### DIFF
--- a/src/FritzBox/Converter.php
+++ b/src/FritzBox/Converter.php
@@ -29,7 +29,7 @@ class Converter
         $this->numbers  = $this->getPhoneNumbers();                      // get array of prequalified phone numbers
         $this->adresses = $this->getEmailAdresses();                     // get array of prequalified email adresses
 
-        while ((count($this->numbers)) || (count($this->adresses))) {
+        while (count($this->numbers)) {
             $this->contact = new SimpleXMLElement('<contact />');
             $this->contact->addChild('carddav_uid', $this->card->uid);    // reference for image upload
             $this->addVip();


### PR DESCRIPTION
Contacts without a phone number and only with an e-mail address are not transferred to the phone book when uploading to the Fritzbox. Therefore, it is useless to pass such contacts to the Fritzbox for upload