### PR TITLE
ftp: use passive mode

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -77,6 +77,9 @@ function uploadImages(array $vcards, array $config, array $phonebook, callable $
     if (!ftp_login($ftp_conn, $config['user'], $config['password'])) {
         throw new \Exception("Could not log in ".$config['user']." to ftp server ".$ftpserver." for image upload.");
     }
+    if (!ftp_pasv($ftp_conn, true)) {
+        throw new \Exception("Could not switch to passive mode on ftp server ".$ftpserver." for image upload.");
+    }
     if (!ftp_chdir($ftp_conn, $config['fonpix'])) {
         throw new \Exception("Could not change to dir ".$config['fonpix']." on ftp server ".$ftpserver." for image upload.");
     }


### PR DESCRIPTION
It's easier to create firewall rules for passive ftp, especially if you're
unable to allow incoming connections to the host running carddav2fb.