### PR TITLE
Subtle reconstruction into the correct division ...

### DIFF
--- a/src/FritzBox/Converter.php
+++ b/src/FritzBox/Converter.php
@@ -32,7 +32,7 @@ class Converter
      * All conversion steps operate on $this->contact
      *
      * @param stdClass $card
-     * @return SimpleXMLElement|null
+     * @return array of SimpleXMLElement|null
      */
     public function convert(stdClass $card)
     {
@@ -54,7 +54,7 @@ class Converter
             $this->addPhone($numberArray);
 
             // add eMail
-            if (count($adresses) && $numberArray = 0) {             // only into the first chunk
+            if (count($adresses)) {
                 $this->addEmail($adresses);
             }
 
@@ -145,6 +145,7 @@ class Converter
             return [];
         }
 
+        $number;
         $addNumber = [];
         $idnum = -1;
 

--- a/src/FritzBox/Converter.php
+++ b/src/FritzBox/Converter.php
@@ -46,7 +46,7 @@ class Converter
 
         $numberArrays = array_chunk($numbers, 9);
 
-        foreach ($numberArrays as $numberArray) {
+        foreach ($numberArrays as $key => $numberArray) {
             $this->contact = new SimpleXMLElement('<contact />');
             $this->contact->addChild('carddav_uid', $card->uid);    // reference for image upload
 
@@ -54,7 +54,7 @@ class Converter
             $this->addPhone($numberArray);
 
             // add eMail
-            if (count($adresses)) {
+            if (count($adresses) && $key == 0) {
                 $this->addEmail($adresses);
             }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -330,9 +330,11 @@ EOT
     $converter = new Converter($conversions);
 
     foreach ($cards as $card) {
-        $contact = $converter->convert($card);
-        if ($contact) {
-            xml_adopt($root, $contact);
+        $contacts = $converter->convert($card);
+        if (isset($contacts)) {
+            foreach ($contacts as $contact) {
+                xml_adopt($root, $contact);
+            }
         }
     }
     return $xml;


### PR DESCRIPTION
... into separate contacts with max. nine phone numbers

Hey Andreas,
your rebuild nine days ago was not completely correct. My tests have shown that convert delivers - instead of a contact with max. nine numbers - only the first phone number per type.
Okay, my "while" loops with "array_shift" were not very elegant. I found a better solution with "array_chunk" and robust "foreach" loops. This will divide the vCard again in contacts with max. nine phone numbers. I tested integratively with different datasets and quantities. I hope this solution finds your approval.