### PR TITLE
changed collection check to == 0 instead of !...

### DIFF
--- a/src/CardDav/Backend.php
+++ b/src/CardDav/Backend.php
@@ -245,7 +245,7 @@ class Backend
 
         foreach ($xml->response as $response) {
             if ((preg_match('/vcard/', $response->propstat->prop->getcontenttype) || preg_match('/vcf/', $response->href)) &&
-              !$response->propstat->prop->resourcetype->collection) {
+              ($response->propstat->prop->resourcetype->collection == 0)) {
                 $id = basename($response->href);
                 $id = str_replace($this->vcard_extension, '', $id);
 


### PR DESCRIPTION
Fix for responses with empty collection attribute.

Responses with empty collection attribute (<collection />) result in XML-Object object(SimpleXMLElement) (0) {}.

Comparing it to 0 evaluates to true because it's content is empty (assume this is the intended behaviour).
Using !$... on this object evaluates to false, because it's a valid object, although it is empty (assume this is wrong behaviour).