### PR TITLE
Support for collections & non-default vcard extension

### DIFF
--- a/config.example.php
+++ b/config.example.php
@@ -17,7 +17,14 @@ $config = [
             'http' => [           // http client options are directly passed to Guzzle http client
                 // 'verify' => false, // uncomment to disable certificate check
                 // 'auth' => 'digest', // uncomment for digest auth
-            ]
+            ],
+            // optional: if server response are collections, choose here the collections to include. If empty, all collections are included.
+            collections => [
+                'collection1',
+                'collection2'
+            ],
+            // optional: vcf_extension for server with other (or no) extension then default .vcf
+            vcf_extension = ''
         ],
 /* add as many as you need
         [

--- a/src/CardDav/Backend.php
+++ b/src/CardDav/Backend.php
@@ -245,7 +245,7 @@ class Backend
 
         foreach ($xml->response as $response) {
             if ((preg_match('/vcard/', $response->propstat->prop->getcontenttype) || preg_match('/vcf/', $response->href)) &&
-              !$response->propstat->prop->resourcetype->collection) {
+              ($response->propstat->prop->resourcetype->collection == 0)) {
                 $id = basename($response->href);
                 $id = str_replace($this->vcard_extension, '', $id);
 

--- a/src/CardDav/Backend.php
+++ b/src/CardDav/Backend.php
@@ -28,7 +28,7 @@ class Backend
      * CardDAV collections to include
      * @var array
      */
-    private $collections;
+    private $collections = [];
 
     /**
      * VCard File URL Extension

--- a/src/CardDav/Backend.php
+++ b/src/CardDav/Backend.php
@@ -64,14 +64,14 @@ class Backend
     {
         if($server)
         {
-            if ($server["url"]) {
-                $this->setUrl($server["url"]);
+            if ($server['url']) {
+                $this->setUrl($server['url']);
             }
             
-            if(isset($server["vcard_extension"]))
+            if(isset($server['vcard_extension']))
             {
                 // workaround for providers that don't use the default .vcf extension
-                $this->vcard_extension = $server["vcard_extension"];
+                $this->vcard_extension = $server['vcard_extension'];
             }
 
             $this->setClientOptions([
@@ -80,9 +80,9 @@ class Backend
                 ]
             ]);
             
-            if(is_array($server["collections"]))
+            if(is_array($server['collections']))
             {
-                $this->collections = $server["collections"];
+                $this->collections = $server['collections'];
             }
         }
     }

--- a/src/functions.php
+++ b/src/functions.php
@@ -21,7 +21,7 @@ function backendProvider(array $config): Backend
 {
     $options = $config['server'] ?? $config;
 
-    $backend = new Backend($options['url']);
+    $backend = new Backend($options);
     $backend->setAuth($options['user'], $options['password']);
     $backend->mergeClientOptions($options['http'] ?? []);
 


### PR DESCRIPTION
Hallo,

die Änderungen sind zur Unterstützung von vcard-collections.
Das Handling von "nicht-standard" vcard extensions (z.B. wenn die extension .vcf in der URL weggelassen wird) habe ich ebenfalls angepasst.

Manche vcard-server geben nicht einzelen vcards (also pro Kontakt eine vcard), sondern eine vcard-collection zurück (alle vcards in einer Datei).

Ich habe den Support für diese vcard-collections eingebaut.
Wenn $response->propstat->prop->resourcetype->collection gesetzt ist, dann wird getVcardsFromCollection ausgeführt (mit $parser->getCards anstatt $parser->getCardAtIndex).

Welche collections heruntergeladen werden, kann in einem Array "collections" im "server"-Array in der config bestimmt werden. Ist das Array leer / nicht gesetzt, dann werden alle collections berücksichtigt.

Außerdem habe ich die hardcoded-Prüfung für die "nicht .vcf-extension server" durch einen config-parameter "vcard_extension" ersetzt.

Funktioniert bei mir soweit, hilft evtl. dem ein oder anderen weiter... :)