### PR TITLE
Alternativ: preserve quickdial and vanity attributes (Fixes #119)

### DIFF
--- a/src/FritzBox/Converter.php
+++ b/src/FritzBox/Converter.php
@@ -174,28 +174,13 @@ class Converter
                     'number' => $number,
                 ];
 
-                // Add quick dial and vanity numbers if card has xquickdial or xvanity attributes set
-                // A phone number with 'PREF' type is needed to activate the attribute.
-                // For quick dial numbers Fritz!Box will add the prefix **7 automatically.
-                // For vanity numbers Fritz!Box will add the prefix **8 automatically.
+                // Add quick dial and vanity numbers if card has quickdial or vanity attributes set
+                // Quick dial or vanity numbers are read from the previous Fritz!Box phonebook.
                 foreach (['quickdial', 'vanity'] as $property) {
-                    $attr = 'x' . $property;
-                    if (!isset($card->$attr)) {
+                    if (!isset($card->$property)) {
                         continue;
                     }
-
-                    if (stripos($numberType, 'pref') === false) {
-                        continue;
-                    }
-
-                    // number unique?
-                    if (in_array($card->$attr, $this->uniqueDials)) {
-                        error_log(sprintf("The %s number >%s< has been assigned more than once (%s)!", $property, $card->$attr, $number));
-                        continue;
-                    }
-
-                    $addNumber[$property] = $card->$attr;
-                    $this->uniqueDials[] = $card->$attr;  // keep list of unique numbers
+                    $addNumber[$property] = $card->$property;
                 }
 
                 $res[] = $addNumber;

--- a/src/RunCommand.php
+++ b/src/RunCommand.php
@@ -83,6 +83,11 @@ class RunCommand extends Command
             unset($this->config['phonebook']['imagepath']);             // otherwise convert will set wrong links
         }
 
+        // enrich with backed-up data
+        $recentPhonebook = downloadPhonebook ($this->config);
+        $specialAttributes = getSpecialAttributes($recentPhonebook);
+        $filtered = setSpecialAttributes($filtered, $specialAttributes);
+
         // fritzbox format
         $xml = export($filtered, $this->config);
         error_log(sprintf(PHP_EOL."Converted %d vCard(s)", count($filtered)));

--- a/src/Vcard/Parser.php
+++ b/src/Vcard/Parser.php
@@ -267,17 +267,6 @@ class Parser implements \IteratorAggregate
                         }
                         $cardData->xabsmember[] = preg_replace('/^urn:uuid:/', '', $value);
                         break;
-                    /* User extended attributes for FritzBox */
-                    case 'X-FB-QUICKDIAL':            // 00-99; Fritz!Box will add the prefix **7 internal
-                        if ($value >= 0 && $value <= 99) {
-                            $cardData->xquickdial =  $value;
-                        }
-                        break;
-                    case 'X-FB-VANITY':               // max. 8 CAPITAL letters; Fritz!Box will add the prefix **8 internal
-                        if (ctype_alpha($value)) {
-                            $cardData->xvanity = substr(strtoupper($value), 0, 8);
-                        }
-                        break;
                 }
             }
         }


### PR DESCRIPTION
Because the discussion about # 120 has fallen asleep, here's my alternative to stimulation:

What is different?
- download recent FRITZ!Box phonebook (equal to Wolfram´s solution) 
- save special attributes (less complex)
- write special attributes into CardDAV data (less complex)