### PR TITLE
Use library for vcard parsing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,11 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": "^7.1",
         "symfony/console": "^3.0",
         "guzzlehttp/guzzle": "^6.0",
-        "ringcentral/psr7": "^1.2"
+        "ringcentral/psr7": "^1.2",
+        "sabre/vobject": "^4.0"
     },
     "autoload": {
         "psr-4": {
@@ -22,6 +23,6 @@
         "files": ["src/functions.php"]
     },
     "require-dev": {
-        "phpunit/phpunit": "^6"
+        "phpunit/phpunit": "^7"
     }
 }

--- a/src/CardDav/Backend.php
+++ b/src/CardDav/Backend.php
@@ -4,6 +4,7 @@ namespace Andig\CardDav;
 
 use Andig\Http\ClientTrait;
 use Andig\Vcard\Parser;
+use Sabre\VObject\Reader;
 use GuzzleHttp\Client;
 use \stdClass;
 
@@ -159,6 +160,10 @@ EOD
                 $vcard = $this->parseVcardFromContent($content);
                 $vcard = $this->enrichVcard($vcard);
                 $cards[] = $vcard;
+
+                $c = Reader::read($content);
+                print_r($c->children());
+                die;
 
                 $this->progress();
             }

--- a/src/CardDav/Backend.php
+++ b/src/CardDav/Backend.php
@@ -158,12 +158,14 @@ EOD
                 $content = (string)$prop->{'address-data'};
 
                 $vcard = $this->parseVcardFromContent($content);
-                $vcard = $this->enrichVcard($vcard);
-                $cards[] = $vcard;
+                // print_r($vcard);
 
-                $c = Reader::read($content);
-                print_r($c->children());
-                die;
+                $vcard = Reader::read($content);
+                $vcard = $vcard->children()[0];
+                // print_r($vcard);
+
+                // $vcard = $this->enrichVcard($vcard);
+                $cards[] = $vcard;
 
                 $this->progress();
             }


### PR DESCRIPTION
Fix #128 *wip*

/cc @blacksenator

it would be great if you could check how this new parser treats our special attributes:

                    /* iCloud extended attributes */
                    case 'X-ADDRESSBOOKSERVER-KIND':
                        $cardData->xabskind = $value;
                        break;
                    case 'X-ADDRESSBOOKSERVER-MEMBER':
                        if (!isset($cardData->xabsmember)) {
                            $cardData->xabsmember = [];
                        }
                        $cardData->xabsmember[] = preg_replace('/^urn:uuid:/', '', $value);
                        break;
                    /* User extended attributes for FritzBox */
                    case 'X-FB-QUICKDIAL':            // 00-99; Fritz!Box will add the prefix **7 internal
                        if ($value >= 0 && $value <= 99) {
                            $cardData->xquickdial =  $value;
                        }
                        break;
                    case 'X-FB-VANITY':               // max. 8 CAPITAL letters; Fritz!Box will add the prefix **8 internal
                        if (ctype_alpha($value)) {
                            $cardData->xvanity = substr(strtoupper($value), 0, 8);
                        }
                        break;

Maybe we can get rid of the custom parser?