### PR TITLE
stripping optional multipart parameter

### DIFF
--- a/src/FritzBox/Api.php
+++ b/src/FritzBox/Api.php
@@ -44,11 +44,10 @@ class Api
      * Multi-part file uploads
      *
      * @param array $formFields
-     * @param array $fileFields
      * @return string POST result
      * @throws \Exception
      */
-    public function postFile(array $formFields, array $fileFields): string
+    public function postFile(array $formFields): string
     {
         $multipart = [];
 
@@ -59,17 +58,6 @@ class Api
             $multipart[] = [
                 'name' => $key,
                 'contents' => $val,
-            ];
-        }
-
-        foreach ($fileFields as $name => $file) {
-            $multipart[] = [
-                'name' => $name,
-                'filename' => $file['filename'],
-                'contents' => $file['content'],
-                'headers' => [
-                    'Content-Type' => $file['type'],
-                ],
             ];
         }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -401,18 +401,11 @@ function uploadPhonebook(SimpleXMLElement $xmlPhonebook, array $config)
     }
 
     $formfields = [
-        'PhonebookId' => $config['phonebook']['id']
+        'PhonebookId' => $config['phonebook']['id'],
+        'PhonebookImportFile' => $xmlPhonebook->asXML(),    // convert XML object to XML string
     ];
 
-    $filefields = [
-        'PhonebookImportFile' => [
-            'type' => 'text/xml',
-            'filename' => 'updatepb.xml',
-            'content' => $xmlPhonebook->asXML(), // convert XML object to XML string
-        ]
-    ];
-
-    $result = $fritz->postFile($formfields, $filefields); // send the command to store new phonebook
+    $result = $fritz->postFile($formfields);                // send the command to store new phonebook
     if (strpos($result, 'Das Telefonbuch der FRITZ!Box wurde wiederhergestellt') === false) {
         throw new \Exception('Upload failed');
     }


### PR DESCRIPTION
According to [Guzzle Dokumentation](http://docs.guzzlephp.org/en/stable/request-options.html#multipart):
> "...headers: **Optional** associative array of custom headers to use with the form element.
filename: **Optional** string to send as the filename in the part..."

and hints from stackoverflow:
>  "...When using the multipart option, you must not specify the Content-Type header yourself. Guzzle will take care of this..."

The upload to the Fritz!Box works just as successfully without these parameters