### PR TITLE
phoneTypes mapping added for work cell number (from nextcloud)

### DIFF
--- a/config.example.php
+++ b/config.example.php
@@ -83,6 +83,7 @@ $config = [
          * The order of the target values (first occurrence) determines the sorting of the telephone numbers
          */
         'phoneTypes' => [
+            'CELL,WORK' => 'work',
             'WORK' => 'work',
             'HOME' => 'home',
             'CELL' => 'mobile',


### PR DESCRIPTION
I added a `phoneTypes` mapping for work cell numbers in the `config.example.php` file. Within the nextcloud contacts app you can specify a work cell number, which is flagged as `CELL,WORK` in the vCard.