### PR TITLE
Save special attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ edit `config.example.php` and save as `config.php`
 
 <img align="right" src="assets/fritzfon.png"/>
 
-### Upload FRITZ!FON background image
+### Upload FRITZ!Fon background image
 
 Using the `background-image` command it is possible to upload the quickdial numbers as background image to FRITZ!Fon (nothing else!)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ This is an entirely simplified version of https://github.com/jens-maus/carddav2f
   * if more than nine phone numbers are included, the contact will be divided into a corresponding number of phonebook entries (any existing email addresses are assigned to the first set [there is no quantity limit!])
   * phone numbers are sorted by type. The order of the conversion values ('phoneTypes') determines the order in the phone book entry
   * the contact's UID of the CardDAV server is added to the phonebook entry (not visible in the FRITZ! Box GUI)
-  * generates an image with keypad and designated quickdial numbers (2-9), which can be uploaded to designated handhelds (see details below)
+  * automatically preserves QuickDial and Vanity attributes of phone numbers set in FRITZ!Box Web GUI. Works without config. These data are saved separately in the internal FRITZ!Box memory under `../FRITZ/mediabox/Atrributes.csv` from loss. The legacy way of configuring your CardDav server with X-FB-QUICKDIAL/X-FB-VANITY is no longer supported.
+  * generates an image with keypad and designated quickdial numbers, which can be uploaded to designated handhelds (see details below)
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ edit `config.example.php` and save as `config.php`
 
 <img align="right" src="assets/fritzfon.png"/>
 
-### Upload Fritz!FON background image
+### Upload FRITZ!FON background image
 
 Using the `background-image` command it is possible to upload the quickdial numbers as background image to FRITZ!Fon (nothing else!)
 
@@ -95,7 +95,7 @@ afterwards).
 
 Without a command, the container entrypoint will enter an endless loop,
 repeatedly executing `carddav2fb run` in given intervals. This allows
-automatic, regular updates of your FritzBox's phonebook.
+automatic, regular updates of your FRITZ!Box's phonebook.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This is an entirely simplified version of https://github.com/jens-maus/carddav2f
   * phone numbers are sorted by type. The order of the conversion values ('phoneTypes') determines the order in the phone book entry
   * the contact's UID of the CardDAV server is added to the phonebook entry (not visible in the FRITZ! Box GUI)
   * automatically preserves QuickDial and Vanity attributes of phone numbers set in FRITZ!Box Web GUI. Works without config. These data are saved separately in the internal FRITZ!Box memory under `../FRITZ/mediabox/Atrributes.csv` from loss. The legacy way of configuring your CardDav server with X-FB-QUICKDIAL/X-FB-VANITY is no longer supported.
-  * generates an image with keypad and designated quickdial numbers, which can be uploaded to designated handhelds (see details below)
+  * generates an image with keypad and designated quickdial numbers (2-9), which can be uploaded to designated handhelds (see details below)
 
 ## Requirements
 

--- a/src/BackgroundCommand.php
+++ b/src/BackgroundCommand.php
@@ -31,12 +31,15 @@ class BackgroundCommand extends Command
         if (count($this->config['fritzbox']['fritzfons']) && $this->config['phonebook']['id'] == 0) {
             error_log('Downloading FRITZ!Box phonebook');
             $xmlPhonebook = downloadPhonebook($this->config['fritzbox'], $this->config['phonebook']);
-            if (count($savedAttributes = uploadAttributes($xmlPhonebook, $this->config['fritzbox']))) {
+            if (count($savedAttributes = uploadAttributes($xmlPhonebook, $this->config))) {
                 error_log('Numbers with special attributes saved' . PHP_EOL);
             } else {                                                    // no attributes are set in the FRITZ!Box or lost
                 $savedAttributes = downloadAttributes($this->config['fritzbox']);   // try to get last saved attributes
             }
-            uploadBackgroundImage($xmlPhonebook, $savedAttributes, $this->config['fritzbox']);
+            $xmlPhonebook = mergeAttributes($xmlPhonebook, $savedAttributes);
+            uploadBackgroundImage($xmlPhonebook, $this->config['fritzbox']);
+        } else {
+            error_log('No destination phones are defined and/or the first phone book is not selected!');
         }
     }
 }

--- a/src/BackgroundCommand.php
+++ b/src/BackgroundCommand.php
@@ -37,7 +37,7 @@ class BackgroundCommand extends Command
                 $savedAttributes = downloadAttributes($this->config['fritzbox']);   // try to get last saved attributes
             }
             $xmlPhonebook = mergeAttributes($xmlPhonebook, $savedAttributes);
-            uploadBackgroundImage($xmlPhonebook, $this->config['fritzbox']);
+            uploadBackgroundImage($xmlPhonebook, $savedAttributes, $this->config['fritzbox']);
         } else {
             error_log('No destination phones are defined and/or the first phone book is not selected!');
         }

--- a/src/BackgroundCommand.php
+++ b/src/BackgroundCommand.php
@@ -27,10 +27,16 @@ class BackgroundCommand extends Command
         $this->loadConfig($input);
 
         // uploading background image
-        if (count($this->config['fritzbox']['fritzfons'])) {
+        $savedAttributes = [];
+        if (count($this->config['fritzbox']['fritzfons']) && $this->config['phonebook']['id'] == 0) {
             error_log('Downloading FRITZ!Box phonebook');
             $xmlPhonebook = downloadPhonebook($this->config['fritzbox'], $this->config['phonebook']);
-            uploadBackgroundImage($xmlPhonebook, $this->config['fritzbox']);
+            if (count($savedAttributes = uploadAttributes($xmlPhonebook, $this->config['fritzbox']))) {
+                error_log('Numbers with special attributes saved' . PHP_EOL);
+            } else {                                                    // no attributes are set in the FRITZ!Box or lost
+                $savedAttributes = downloadAttributes($this->config['fritzbox']);   // try to get last saved attributes
+            }
+            uploadBackgroundImage($xmlPhonebook, $savedAttributes, $this->config['fritzbox']);
         }
     }
 }

--- a/src/FritzBox/BackgroundImage.php
+++ b/src/FritzBox/BackgroundImage.php
@@ -212,7 +212,7 @@ EOD;
                 continue;
             }
 
-            error_log(sprintf("Uploading background image to Fritz!Fon #%s", $phone));
+            error_log(sprintf("Uploading background image to FRITZ!Fon #%s", $phone));
 
             $body = $this->getBody($fritz->getSID(), $phone, $backgroundImage);
             $result = $fritz->postImage($body);

--- a/src/FritzBox/Converter.php
+++ b/src/FritzBox/Converter.php
@@ -83,7 +83,8 @@ class Converter
         // check if phone number is a SIP or internal number to avoid unwanted conversions
         if (filter_var($number, FILTER_VALIDATE_EMAIL) || substr($number, 0, 2) == '**') {
             return $number;
-        } elseif (count($this->config['phoneReplaceCharacters'])) {
+        }
+        if (count($this->config['phoneReplaceCharacters'])) {
             $number = str_replace("\xc2\xa0", "\x20", $number);
             $number = strtr($number, $this->config['phoneReplaceCharacters']);
             $number = trim(preg_replace('/\s+/', ' ', $number));

--- a/src/FritzBox/Converter.php
+++ b/src/FritzBox/Converter.php
@@ -178,34 +178,10 @@ class Converter
             if (strpos($telTypes, 'FAX') !== false) {
                 $type = 'fax_work';
             }
-
             $addNumber = [
                 'type'   => $type,
                 'number' => (string)$number,
             ];
-
-            /* Add quick dial and vanity numbers if card has xquickdial or xvanity attributes set
-             * A phone number with 'PREF' type is needed to activate the attribute.
-             * For quick dial numbers Fritz!Box will add the prefix **7 automatically.
-             * For vanity numbers Fritz!Box will add the prefix **8 automatically. */
-            foreach (['quickdial', 'vanity'] as $property) {
-                $attr = 'X-FB-' . strtoupper($property);
-                if (!isset($card->$attr)) {
-                    continue;
-                }
-                if (strpos($telTypes, 'PREF') === false) {
-                    continue;
-                }
-                $specialAttribute = (string)$card->$attr;
-                // number unique?
-                if (in_array($specialAttribute, $this->uniqueDials)) {
-                    error_log(sprintf("The %s number >%s< has been assigned more than once (%s)!", $property, $specialAttribute, $number));
-                    continue;
-                }
-                $this->uniqueDials[] = $specialAttribute;                    // keep list of unique numbers
-                $addNumber[$property] = $specialAttribute;
-            }
-
             $phoneNumbers[] = $addNumber;
         }
 

--- a/src/FritzBox/Restorer.php
+++ b/src/FritzBox/Restorer.php
@@ -81,7 +81,7 @@ class Restorer
             // get the contacts header data (name and UID)
             $contact = $number->xpath("./ancestor::contact");
             $attributes['name'] = (string)$contact[0]->person->realName;
-            $uid = empty((string)$contact[0]->carddav_uid) ? uniqid() : (string)$contact[0]->carddav_uid;
+            $uid = (string)$contact[0]->carddav_uid ?: uniqid();
             $phonebookData[$uid] = $attributes;
         }
 

--- a/src/FritzBox/Restorer.php
+++ b/src/FritzBox/Restorer.php
@@ -81,11 +81,8 @@ class Restorer
             // get the contacts header data (name and UID)
             $contact = $number->xpath("./ancestor::contact");
             $attributes['name'] = (string)$contact[0]->person->realName;
-            if (empty((string)$contact[0]->carddav_uid)) {              // internal numbers have no id, but we need one
-                $phonebookData[uniqid()] = $attributes;
-            } else {
-                $phonebookData[(string)$contact[0]->carddav_uid] = $attributes;
-            }
+            $uid = empty((string)$contact[0]->carddav_uid) ? uniqid() : (string)$contact[0]->carddav_uid;
+            $phonebookData[$uid] = $attributes;
         }
 
         return $phonebookData;

--- a/src/FritzBox/Restorer.php
+++ b/src/FritzBox/Restorer.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace Andig\FritzBox;
+
+use Andig\FritzBox\Converter;
+use Sabre\VObject\Document;
+use \SimpleXMLElement;
+
+/**
+ * Copyright (c) 2019 Volker Püschel
+ * @license MIT
+ */
+
+class Restorer
+{
+    const CSV_HEADER = 'uid,number,id,type,quickdial,vanity,prio,name';
+
+    private $collums = [];
+
+    public function __construct()
+    {
+        $this->collums = explode(',', self::CSV_HEADER);
+    }
+
+    /**
+     * get an empty associated array according to CSV_HEADER
+     * [ 'number' => '',
+     *   'id' => '',
+     *   'type' => '',
+     *   'quickdial' => '',
+     *   'vanity' => '',
+     *   'prio' => '',
+     *   'name' => '']
+     *
+     * @return array
+     */
+    private function getPlainArray()
+    {
+        $csvHeader = explode(',', self::CSV_HEADER);
+        $dump = array_shift($csvHeader);            // eliminate the first column header (uid)
+
+        return array_fill_keys($csvHeader, '');
+    }
+
+    /**
+     * Get quickdial and vanity special attributes and
+     * internal numbers ('**[n]' from given XML phone book
+     * return is an array according to CSV_HEADER:
+     * ['foo-bar' => [            // uid
+     *      'number' => '1',
+     *      'id' => '1',
+     *      'type' => 'foo',
+     *      'quickdial' => '1',
+     *      'vanity' => 'bar',
+     *      'prio' => '1',
+     *      'name' => 'baz']
+     * ],
+     *
+     * @param SimpleXMLElement $xmlPhonebook
+     * @return array an array of special attributes with CardDAV UID as key
+     */
+    public function getPhonebookData(SimpleXMLElement $xmlPhonebook, array $conversions)
+    {
+        if (!property_exists($xmlPhonebook, "phonebook")) {
+            return [];
+        }
+
+        $converter = new Converter($conversions);
+        $phonebookData = [];
+
+        $numbers = $xmlPhonebook->xpath('//number[@quickdial or @vanity] | //number[starts-with(text(),"**")]');
+
+        foreach ($numbers as $number) {
+            $attributes = $this->getPlainArray();                   // it´s easier to handle with the full set
+            // regardless of how the number was previously converted, the current config is applied here
+            $attributes['number'] = $converter->convertPhonenumber((string)$number);
+            // get all phone number attibutes
+            foreach ($number->attributes() as $key => $value) {
+                $attributes[(string)$key] = (string)$value;
+            }
+            // get the contacts header data (name and UID)
+            $contact = $number->xpath("./ancestor::contact");
+            $attributes['name'] = (string)$contact[0]->person->realName;
+            if (empty((string)$contact[0]->carddav_uid)) {              // internal numbers have no id, but we need one
+                $phonebookData[uniqid()] = $attributes;
+            } else {
+                $phonebookData[(string)$contact[0]->carddav_uid] = $attributes;
+            }
+        }
+
+        return $phonebookData;
+    }
+
+    /**
+     * get a xml contact structure from saved internal numbers
+     *
+     * @param string $uid
+     * @param array $internalNumber
+     * @return SimpleXMLElement $contact
+     */
+    private function getInternalContact(string $uid, array $internalNumber)
+    {
+        $contact = new SimpleXMLElement('<contact />');
+        $contact->addChild('carddav_uid', $uid);
+        $telephony = $contact->addChild('telephony');
+        $number = $telephony->addChild('number', $internalNumber['number']);
+        $number->addAttribute('id', $internalNumber['id']);
+        $number->addAttribute('type', $internalNumber['type']);
+        $person = $contact->addChild('person');
+        $person->addChild('realName', $internalNumber['name']);
+
+        return $contact;
+    }
+
+    /**
+     * Attach xml element to parent
+     * https://stackoverflow.com/questions/4778865/php-simplexml-addchild-with-another-simplexmlelement
+     *
+     * @param SimpleXMLElement $to
+     * @param SimpleXMLElement $from
+     * @return void
+     */
+    public function xml_adopt(SimpleXMLElement $to, SimpleXMLElement $from)
+    {
+        $toDom = dom_import_simplexml($to);
+        $fromDom = dom_import_simplexml($from);
+        $toDom->appendChild($toDom->ownerDocument->importNode($fromDom, true));
+    }
+
+    /**
+     * Restore special attributes (quickdial, vanity) and internal phone numbers
+     * in given target phone book
+     *
+     * @param SimpleXMLElement $xmlTargetPhoneBook
+     * @param array $attributes array of special attributes
+     * @return SimpleXMLElement phonebook with restored special attributes
+     */
+    public function setPhonebookData(SimpleXMLElement $xmlTargetPhoneBook, array $attributes)
+    {
+        $root = $xmlTargetPhoneBook->xpath('//phonebook')[0];
+
+        error_log('Restoring saved attributes (quickdial, vanity) and internal numbers');
+        foreach ($attributes as $key => $values) {
+            if (substr($values['number'], 0, 2) == '**') {      // internal number
+                $contact = $this->getInternalContact($key, $values);
+                $this->xml_adopt($root, $contact);              // add contact with internal number
+            }
+            if ($contact = $xmlTargetPhoneBook->xpath(sprintf('//contact[carddav_uid = "%s"]', $key))) {
+                if ($phone = $contact[0]->xpath(sprintf("telephony/number[text() = '%s']", $values['number']))) {
+                    foreach (['quickdial', 'vanity'] as $attribute) {
+                        if (!empty($values[$attribute])) {
+                            $phone[0]->addAttribute($attribute, $values[$attribute]);
+                        }
+                    }
+                }
+            }
+        }
+
+        return $xmlTargetPhoneBook;
+    }
+
+    /**
+     * convert internal phonbook data (array of SimpleXMLElement) to string (rows of csv)
+     *
+     * @param array $phonebookData
+     * @return string $row csv
+     */
+    public function phonebookDataToCSV($phonebookData)
+    {
+        $row = self::CSV_HEADER . PHP_EOL;                            // csv header row
+        foreach ($phonebookData as $uid => $values) {
+            $row .= $uid;                                 // array key first collum
+            foreach ($values as $key => $value) {
+                if ($key == 'name') {
+                    $value = '"' . $value . '"';
+                }
+                $row .= ',' . $value;                           // values => collums
+            }
+            if (next($phonebookData) == true) {
+                $row .= PHP_EOL;
+            }
+        }
+
+        return $row;
+    }
+
+        /**
+     * convert csv line to internal phonbook data
+     *
+     * @param array $csvRow
+     * @return array $phonebookData
+     */
+    public function csvToPhonebookData($csvRow)
+    {
+        $rows = '';
+        $uid = '';
+        $phonebookData = [];
+
+        if (count($csvRow) <> count($this->collums)) {
+            throw new \Exception('The number of csv columns does not match the default!');
+        }
+        if ($csvRow <> $this->collums) {                    // values equal CSV_HEADER
+            foreach ($csvRow as $key => $value) {
+                if ($key == 0) {
+                    $uid = $value;
+                } else {
+                    $phonebookData[$uid][$this->collums[$key]] = $value;
+                }
+            }
+        }
+
+        return $phonebookData;
+    }
+}

--- a/src/FritzBox/Restorer.php
+++ b/src/FritzBox/Restorer.php
@@ -184,7 +184,7 @@ class Restorer
         return $row;
     }
 
-        /**
+    /**
      * convert csv line to internal phonbook data
      *
      * @param array $csvRow

--- a/src/RunCommand.php
+++ b/src/RunCommand.php
@@ -34,6 +34,7 @@ class RunCommand extends Command
         }
 
         // download recent phonebook and save special attributes
+        $savedAttributes = [];
         $recentPhonebook = downloadPhonebook($this->config['fritzbox'], $this->config['phonebook']);
         if ($this->config['phonebook']['id'] == 0) {                            // only the first phonebook has special attributes
             if (count($savedAttributes = uploadAttributes($recentPhonebook, $this->config['fritzbox']))) {

--- a/src/RunCommand.php
+++ b/src/RunCommand.php
@@ -42,6 +42,8 @@ class RunCommand extends Command
         } else {                        // no attributes are set in the FRITZ!Box or lost -> try to download them
             $savedAttributes = downloadAttributes($this->config['fritzbox']);   // try to get last saved attributes
         }
+
+        // download from server or lokal files
         $vcards = $this->downloadAllProviders($output, $input->getOption('image'));
         error_log(sprintf("Downloaded %d vCard(s) in total", count($vcards)));
 

--- a/src/UploadCommand.php
+++ b/src/UploadCommand.php
@@ -16,7 +16,7 @@ class UploadCommand extends Command
     protected function configure()
     {
         $this->setName('upload')
-            ->setDescription('Upload to Fritz!Box')
+            ->setDescription('Upload to FRITZ!Box')
             ->addArgument('filename', InputArgument::REQUIRED, 'filename');
 
         $this->addConfig();
@@ -25,13 +25,19 @@ class UploadCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->loadConfig($input);
+        $savedAttributes = [];
 
         $filename = $input->getArgument('filename');
         $xmlPhonebookStr = file_get_contents($filename);
         $xmlPhonebook = simplexml_load_string($xmlPhonebookStr);
 
-        error_log("Uploading Fritz!Box phonebook");
-        uploadPhonebook($xmlPhonebook, [], $this->config);
-        error_log("Successful uploaded new Fritz!Box phonebook");
+        if ($this->config['phonebook']['id'] == 0) {                // only the first phonebook has special attributes
+            $savedAttributes = downloadAttributes($this->config['fritzbox']);   // try to get last saved attributes
+            $xmlPhonebook = mergeAttributes($xmlPhonebook, $savedAttributes);
+        }
+
+        error_log("Uploading FRITZ!Box phonebook");
+        uploadPhonebook($xmlPhonebook, $this->config);
+        error_log("Successful uploaded new FRITZ!Box phonebook");
     }
 }

--- a/src/UploadCommand.php
+++ b/src/UploadCommand.php
@@ -31,7 +31,7 @@ class UploadCommand extends Command
         $xmlPhonebook = simplexml_load_string($xmlPhonebookStr);
 
         error_log("Uploading Fritz!Box phonebook");
-        uploadPhonebook($xmlPhonebook, $this->config);
+        uploadPhonebook($xmlPhonebook, [], $this->config);
         error_log("Successful uploaded new Fritz!Box phonebook");
     }
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -572,7 +572,7 @@ function uploadBackgroundImage($phonebook, $attributes, array $config)
  *
  * @param SimpleXMLElement $phonebook
  * @param array $config
- * @return string|void
+ * @return array
  */
 function uploadAttributes($phonebook, $config)
 {
@@ -590,7 +590,7 @@ function uploadAttributes($phonebook, $config)
     fputs($memstream, $rows);
     rewind($memstream);
     if (!ftp_fput($ftp_conn, 'Attributes.csv', $memstream, FTP_BINARY)) {
-        error_log(sprintf('Error uploadind %s!' . PHP_EOL, $csv_filename));
+        error_log('Error uploading Attributes.csv!' . PHP_EOL);
     }
     fclose($memstream);
     ftp_close($ftp_conn);
@@ -602,7 +602,7 @@ function uploadAttributes($phonebook, $config)
  * get saved special attributes from internal FRITZ!Box memory (../FRITZ/mediabox)
  *
  * @param array $config
- * @return array|void
+ * @return array
  */
 function downloadAttributes($config)
 {
@@ -613,10 +613,14 @@ function downloadAttributes($config)
         return [];
     }
 
+    $collums = '';
+    $rows = '';
+    $uid = '';
+    $specialAttributes = [];
+
     $csvFile = fopen('php://temp', 'r+');
     if (ftp_fget($ftp_conn, $csvFile, 'Attributes.csv', FTP_BINARY)) {
         rewind($csvFile);
-        $specialAttributes = [];
         while ($csvRow = fgetcsv($csvFile)) {
             if (!count(array_diff(explode(',', CSV_HEADER), $csvRow))) {    // all CSV_HEADER elements are in csvRow => header line
                 $collums = $csvRow;
@@ -640,10 +644,11 @@ function downloadAttributes($config)
 /**
  * convert special atributes (array of SimpleXMLElement) to string (rows of csv)
  *
- * @param array $arrayOfXML
+ * @param array $specialAttributes
  * @return string csv
  */
-function xmlArrayToCSV($specialAttributes) {
+function xmlArrayToCSV($specialAttributes)
+{
     $row = CSV_HEADER . PHP_EOL;                            // csv header row
     foreach ($specialAttributes as $uid => $values) {
         $row = $row . $uid;                                 // array key first collum
@@ -655,5 +660,6 @@ function xmlArrayToCSV($specialAttributes) {
         }
         $row = $row . PHP_EOL;                              // next row
     }
+
     return $row;
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -463,6 +463,7 @@ function getPhoneNumberAttributes(SimpleXMLElement $xmlPhonebook)
         return [];
     }
 
+    $specialAttributes = [];
     $numbers = $xmlPhonebook->xpath('//number[@quickdial or @vanity]');
     foreach ($numbers as $number) {
         $attributes = [];

--- a/tests/ConverterTest.php
+++ b/tests/ConverterTest.php
@@ -164,31 +164,6 @@ class ConverterTest extends TestCase
         $this->assertEquals('fax_work', (string)$faxNumber['type']);
     }
 
-    public function testVanityAndQuickdialNumbers()
-    {
-        unset($this->contact->TEL);
-        $this->contact->add('TEL', '1', ['type' => 'other']);
-        $this->contact->add('TEL', '2', ['type' => 'pref']);
-        $this->contact->{'X-FB-QUICKDIAL'} = 'quickdial';
-        $this->contact->{'X-FB-VANITY'} = 'vanity';
-
-        $res = $this->converter->convert($this->contact);
-        $this->assertCount(1, $res);
-
-        $contact = $res[0];
-        $this->assertCount(2, $contact->telephony->children());
-
-        // first number without pref/vanity
-        $vanityNumber = $contact->telephony->children()[0];
-        $this->assertNull($vanityNumber['quickdial']);
-        $this->assertNull($vanityNumber['vanity']);
-
-        // second number with pref/vanity
-        $vanityNumber = $contact->telephony->children()[1];
-        $this->assertEquals('quickdial', (string)$vanityNumber['quickdial']);
-        $this->assertEquals('vanity', (string)$vanityNumber['vanity']);
-    }
-
     public function testMoreThan10PhoneNumbers()
     {
         unset($this->contact->TEL);

--- a/tests/ConverterTest.php
+++ b/tests/ConverterTest.php
@@ -28,6 +28,14 @@ class ConverterTest extends TestCase
                     'CELL' => 'mobile',
                     'FAX' => 'fax_work'
                 ],
+                'phoneReplaceCharacters' => [
+                    '+49' => '',
+                    '('   => '',
+                    ')'   => '',
+                    '/'   => '',
+                    '@'   => '',
+                    '-'   => ''
+                ],
                 'realName' => [],
             ],
         ];
@@ -201,5 +209,26 @@ class ConverterTest extends TestCase
         // default type = 'other'
         $numberType = $res[0]->telephony->children()[0];
         $this->assertEquals('other', (string)$numberType['type']);
+    }
+
+    public function testPhonenumberConversionType()
+    {
+        unset($this->contact->TEL);
+        $this->contact->add('TEL', 'foo@sip.de', ['type' => 'work']);
+        $this->contact->add('TEL', '(0511)12345/678-890', ['type' => 'home']);
+
+        $res = $this->converter->convert($this->contact);
+        $this->assertCount(1, $res);
+
+        $contact = $res[0];
+        $this->assertCount(2, $contact->telephony->children());
+
+        // no number conversion
+        $number = $contact->telephony->children()[0];
+        $this->assertEquals('foo@sip.de', (string)$number);
+
+        // number conversion
+        $number = $contact->telephony->children()[1];
+        $this->assertEquals('051112345678890', (string)$number);
     }
 }

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -87,52 +87,6 @@ EOD;
         return simplexml_load_string($xml);
     }
 
-    private function injectQuickDialAndVanity(SimpleXMLElement $phonebook, $contIndex, $numIndex, $qd, $van): SimpleXMLElement
-    {
-        $phonebook->phonebook->contact[$contIndex]->telephony->number[$numIndex]['quickdial'] = $qd;
-        $phonebook->phonebook->contact[$contIndex]->telephony->number[$numIndex]['vanity'] = $van;
-        return $phonebook;
-    }
-
-    public function testGetPhoneNumberAttributes()
-    {
-        $phonebook = $this->defaultPhonebook();
-        $phonebook = $this->injectQuickDialAndVanity($phonebook, 0, 0, "11", "AX");
-
-        $attributes = Andig\getPhoneNumberAttributes($phonebook);
-
-        // This key should be there
-        $expectedKey = 'ABCDEFGH-8AA4-4389-A2BE-18A42A61D24D';
-        $this->assertEquals(1, count($attributes));
-        $this->assertArrayHasKey($expectedKey, $attributes);
-
-        // Now check if expected quickdial / vanity attributes have been found
-        $this->assertEquals('11', $attributes[$expectedKey]['quickdial']);
-        $this->assertEquals('AX', $attributes[$expectedKey]['vanity']);
-    }
-
-    public function testMergePhoneNumberAttributes()
-    {
-        $phonebook = $this->defaultPhonebook();
-        $phonebook = $this->injectQuickDialAndVanity($phonebook, 0, 0, "11", "AX");
-        $phonebook = $this->injectQuickDialAndVanity($phonebook, 1, 1, "22", "AG");
-
-        $attributes = Andig\getPhoneNumberAttributes($phonebook);
-        $newPhoneBook = Andig\mergePhoneNumberAttributes($phonebook, $attributes);
-
-        // Here we expect quickdial & vanity
-        $this->assertEquals('11', $newPhoneBook->phonebook->contact[0]->telephony->number[0]['quickdial']);
-        $this->assertEquals('22', $newPhoneBook->phonebook->contact[1]->telephony->number[1]['quickdial']);
-        $this->assertEquals('AX', $newPhoneBook->phonebook->contact[0]->telephony->number[0]['vanity']);
-        $this->assertEquals('AG', $newPhoneBook->phonebook->contact[1]->telephony->number[1]['vanity']);
-
-        // These contact numbers should NOT have quickdial or vanity
-        $this->assertEquals(false, isset($newPhoneBook->phonebook->contact[0]->telephony->number[1]['quickdial']));
-        $this->assertEquals(false, isset($newPhoneBook->phonebook->contact[1]->telephony->number[0]['quickdial']));
-        $this->assertEquals(false, isset($newPhoneBook->phonebook->contact[0]->telephony->number[1]['vanity']));
-        $this->assertEquals(false, isset($newPhoneBook->phonebook->contact[1]->telephony->number[0]['vanity']));
-    }
-
     public function filtersPropertiesProvider(): array
     {
         return [

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -94,21 +94,6 @@ EOD;
         return $phonebook;
     }
 
-    public function testGenerateUniqueKey()
-    {
-        $uid = 'abcdef';
-        $number = '0913111111';
-        $this->assertEquals('0913111111@abcdef', Andig\generateUniqueKey($number, $uid));
-    }
-
-    public function testGenerateUniqueKeyWithNormalizedNumber()
-    {
-        $uid = 'abcdef';
-        $number = '09131-111 11';
-        $this->assertEquals('0913111111@abcdef', Andig\generateUniqueKey($number, $uid),
-                            'generateUniqueKey() should normalize phone numbers');
-    }
-
     public function testPhoneNumberAttributesSetFalse()
     {
         $phonebook = $this->defaultPhonebook();
@@ -133,13 +118,13 @@ EOD;
         $attributes = Andig\getPhoneNumberAttributes($phonebook);
 
         // This key should be there
-        $expectedKey = '09131123456@ABCDEFGH-8AA4-4389-A2BE-18A42A61D24D';
+        $expectedKey = 'ABCDEFGH-8AA4-4389-A2BE-18A42A61D24D';
         $this->assertEquals(1, count($attributes));
         $this->assertArrayHasKey($expectedKey, $attributes);
 
         // Now check if expected quickdial / vanity attributes have been found
-        $this->assertEquals('11', $attributes[$expectedKey]->quickdial);
-        $this->assertEquals('AX', $attributes[$expectedKey]->vanity);
+        $this->assertEquals('11', $attributes[$expectedKey]['quickdial']);
+        $this->assertEquals('AX', $attributes[$expectedKey]['vanity']);
     }
 
     public function testMergePhoneNumberAttributes()

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -94,22 +94,6 @@ EOD;
         return $phonebook;
     }
 
-    public function testPhoneNumberAttributesSetFalse()
-    {
-        $phonebook = $this->defaultPhonebook();
-        $this->assertEquals(false, Andig\phoneNumberAttributesSet($phonebook),
-                            'phoneNumberAttributesSet() should not detect any quickdial / vanity attributes');
-    }
-
-    public function testPhoneNumberAttributesSetTrue()
-    {
-        $phonebook = $this->defaultPhonebook();
-        $phonebook = $this->injectQuickDialAndVanity($phonebook, 0, 0, "11", "AX");
-
-        $this->assertEquals(true, Andig\phoneNumberAttributesSet($phonebook),
-                            'phoneNumberAttributesSet() should detect set quickdial / vanity attributes');
-    }
-
     public function testGetPhoneNumberAttributes()
     {
         $phonebook = $this->defaultPhonebook();

--- a/tests/RestorerTest.php
+++ b/tests/RestorerTest.php
@@ -1,0 +1,155 @@
+<?php
+
+use \Andig\FritzBox\Restorer;
+use \PHPUnit\Framework\TestCase;
+
+class RestorerTest extends TestCase
+{
+    /** @var Restorer */
+    public $restore;
+
+    public function setUp()
+    {
+        $this->restore = new Restorer;
+    }
+
+    private function defaultConfig(): array
+    {
+        return [
+            'conversions' => [
+                'phoneTypes' => [
+                    'WORK' => 'work',
+                    'HOME' => 'home',
+                    'CELL' => 'mobile',
+                    'FAX' => 'fax_work',
+                ],
+                'phoneReplaceCharacters' => [
+                    '+49' => '',
+                    '('   => '',
+                    ')'   => '',
+                    '@'   => '',
+                    '/'   => '',
+                    '-'   => '',
+                ],
+            ],
+        ];
+    }
+
+    private function defaultPhonebook(): SimpleXMLElement
+    {
+        $xml =                 <<<EOD
+<?xml version="1.0" encoding="UTF-8"?>
+<phonebooks>
+    <phonebook name="Telefonbuch">
+        <contact>
+            <carddav_uid>ABCDEFGH-8AA4-4389-A2BE-18A42A61D24D</carddav_uid>
+            <telephony>
+                <number id="0" type="work">09131123456</number>
+                <number id="1" type="home">0911123456</number>
+                <number id="2" type="mobile">0152123456</number>
+            </telephony>
+            <person>
+                <realName>Mustermann, Max</realName>
+                <imageURL>file:///var/InternerSpeicher/MyUSB/FRITZ/fonpix/ABCDEFGH-8AA4-4389-A2BE-18A42A61D24D.jpg</imageURL>
+            </person>
+        </contact>
+        <contact>
+            <carddav_uid>ABCDEFGH-8AA4-4389-A2BE-18A42A61D24E</carddav_uid>
+            <telephony>
+                <number id="0" type="work">09131345678</number>
+                <number id="1" type="home">0911345678</number>
+                <number id="2" type="mobile">0152345678</number>
+            </telephony>
+            <person>
+                <realName>Mustermann, Marianne</realName>
+                <imageURL>file:///var/InternerSpeicher/MyUSB/FRITZ/fonpix/ABCDEFGH-8AA4-4389-A2BE-18A42A61D24E.jpg</imageURL>
+            </person>
+        </contact>
+    </phonebook>
+</phonebooks>
+EOD;
+
+        return simplexml_load_string($xml);
+    }
+
+    private function defaultCSV(): string
+    {
+        $header = $this->restore::CSV_HEADER;
+        $csv = <<<EOD
+$header
+ABCDEFGH-8AA4-4389-A2BE-18A42A61D24D,09131123456,0,home,8,,1,""
+E2B70D3D-FF6E-4E14-98C5-B334E18BF98D,**611,0,home,99,,1,Gruppenruf
+ABCDEFGH-8AA4-4389-A2BE-18A42A61D24E,0152345678,0,home,,FOO,1,""
+EOD;
+
+    return $csv;
+    }
+
+    private function injectQuickDialAndVanity(SimpleXMLElement $phonebook, $contIndex, $numIndex, $qd, $van): SimpleXMLElement
+    {
+        $phonebook->phonebook->contact[$contIndex]->telephony->number[$numIndex]['quickdial'] = $qd;
+        $phonebook->phonebook->contact[$contIndex]->telephony->number[$numIndex]['vanity'] = $van;
+        return $phonebook;
+    }
+
+    public function testgetPhonebookData()
+    {
+        $phonebook = $this->defaultPhonebook();
+        $phonebook = $this->injectQuickDialAndVanity($phonebook, 0, 0, "11", "AX");
+
+        $attributes = $this->restore->getPhonebookData($phonebook, $this->defaultconfig());
+
+        // This key should be there
+        $expectedKey = 'ABCDEFGH-8AA4-4389-A2BE-18A42A61D24D';
+        $this->assertEquals(1, count($attributes));
+        $this->assertArrayHasKey($expectedKey, $attributes);
+
+        // Now check if expected quickdial / vanity attributes have been found
+        $this->assertEquals('11', $attributes[$expectedKey]['quickdial']);
+        $this->assertEquals('AX', $attributes[$expectedKey]['vanity']);
+
+        $newCSV = $this->restore->phonebookDataToCSV($attributes);
+        $rows = explode(PHP_EOL, $newCSV);
+
+        $this->assertEquals(2, count($rows));
+        $this->assertEquals($this->restore::CSV_HEADER, $rows[0]);
+    }
+
+    public function testsetPhonebookData()
+    {
+        $attributes = [];
+        $rows = explode(PHP_EOL, $this->defaultCSV());
+        foreach ($rows as $row) {
+            $csvRow = explode(',', $row);
+            $attributes = array_merge($this->restore->csvToPhonebookData($csvRow), $attributes);
+        }
+
+        $this->assertEquals(3, count($attributes));
+
+        $newPhoneBook = $this->restore->setPhonebookData($this->defaultPhonebook(), $attributes);
+
+        $res = $newPhoneBook->xpath('//contact');
+        $this->assertEquals(3, count($res));
+
+        $this->assertEquals('8', $newPhoneBook->phonebook->contact[0]->telephony->number[0]['quickdial']);
+        $this->assertEquals(false, isset($newPhoneBook->phonebook->contact[0]->telephony->number[0]['vanity']));
+        $this->assertEquals(false, isset($newPhoneBook->phonebook->contact[0]->telephony->number[1]['quickdial']));
+        $this->assertEquals(false, isset($newPhoneBook->phonebook->contact[0]->telephony->number[1]['vanity']));
+        $this->assertEquals(false, isset($newPhoneBook->phonebook->contact[0]->telephony->number[2]['quickdial']));
+        $this->assertEquals(false, isset($newPhoneBook->phonebook->contact[0]->telephony->number[2]['vanity']));
+
+        $this->assertEquals(false, isset($newPhoneBook->phonebook->contact[1]->telephony->number[0]['quickdial']));
+        $this->assertEquals(false, isset($newPhoneBook->phonebook->contact[1]->telephony->number[0]['vanity']));
+        $this->assertEquals(false, isset($newPhoneBook->phonebook->contact[1]->telephony->number[1]['quickdial']));
+        $this->assertEquals(false, isset($newPhoneBook->phonebook->contact[1]->telephony->number[1]['vanity']));
+        $this->assertEquals('FOO', $newPhoneBook->phonebook->contact[1]->telephony->number[2]['vanity']);
+        $this->assertEquals(false, isset($newPhoneBook->phonebook->contact[1]->telephony->number[2]['quickdial']));
+
+        $this->assertEquals(1, count($newPhoneBook->phonebook->contact[2]->telephony->number));
+        $this->assertEquals('E2B70D3D-FF6E-4E14-98C5-B334E18BF98D', $newPhoneBook->phonebook->contact[2]->carddav_uid);
+        $this->assertEquals('Gruppenruf', $newPhoneBook->phonebook->contact[2]->person->realName);
+        $this->assertEquals('**611', $newPhoneBook->phonebook->contact[2]->telephony->number[0]);
+        $this->assertEquals('99', $newPhoneBook->phonebook->contact[2]->telephony->number[0]['quickdial']);
+        $this->assertEquals(false, isset($newPhoneBook->phonebook->contact[2]->telephony->number[0]['vanity']));
+    }
+}


### PR DESCRIPTION
The idea behind this feature branch is that the special phone attributes (which are not loaded by the CardDAV server) are stored for backup in the internal memory of the Fritz! Box (csv file). This also protects possible data loss, such as during firmware upgrades or unintentional deletion of the first phone book.
Thus, the old solution with X-FB-* properties is completely superfluous.