### PR TITLE
Fix PHP Fatal error about the missing return value

### DIFF
--- a/src/RunCommand.php
+++ b/src/RunCommand.php
@@ -93,6 +93,9 @@ class RunCommand extends Command
         if (count($this->config['fritzbox']['fritzfons']) && $this->config['phonebook']['id'] == 0) {
             uploadBackgroundImage($xmlPhonebook, $savedAttributes, $this->config['fritzbox']);
         }
+
+        // Return 0 on success
+        return 0;
     }
 
     /**


### PR DESCRIPTION
PHP Fatal error:  Uncaught TypeError: Return value of "Andig\RunCommand::execute()" must be of the type int, NULL returned. in /carddav2fb/vendor/symfony/console/Command/Command.php:258

When executing ` ./carddav2fb run -i` the code run successfully but errors with the fatal error mention above. This here should fix the problem.

Thanks for this awesome project here 👍 