### PR TITLE
Include VCARDs without CATEGORIES when filtering

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -421,6 +421,10 @@ function filtersMatch(Document $vcard, array $filters): bool
             if (array_intersect($vcard->$param->getParts(), $values)) {
                 return true;
             }
+        } else {
+            if (in_array('', $values)) {
+                return true;
+            }
         }
     }
 


### PR DESCRIPTION
When filtering include VCARDs without CATEGORIES, if the filter list includes the empty string ("").
Otherwise VCARDs without a CATEGORIES attribute will always get filtered out, if categories-filters are defined.
