### PR TITLE
fixing quickdial and vanity for internal numbers 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ cache
 /workbench/test.php
 /workbench/test1.php
 /workbench/wolf_cfg.php
+/.vscode/launch.json

--- a/src/FritzBox/Restorer.php
+++ b/src/FritzBox/Restorer.php
@@ -102,6 +102,11 @@ class Restorer
         $number = $telephony->addChild('number', $internalNumber['number']);
         $number->addAttribute('id', $internalNumber['id']);
         $number->addAttribute('type', $internalNumber['type']);
+        foreach (self::AVM_ATTRIBUTES as $attribute) {
+            if (!empty($internalNumber[$attribute])) {
+                $number->addAttribute($attribute, $internalNumber[$attribute]);
+            }
+        }
 
         return $number;
     }


### PR DESCRIPTION
fixing that for internal phone numbers, possibly assigned quickdial and vanity numbers were ignored during the restore