### PR TITLE
Update PHP Version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.22
 LABEL description="Download CardDAV VCards and upload as phonebook to AVM FRITZ!Box"
 
 VOLUME [ "/data" ]
@@ -7,17 +7,17 @@ VOLUME [ "/data" ]
 RUN set -xe && \
     apk update && apk upgrade && \
     apk add --no-cache --virtual=run-deps \
-        php7-cli \
-        php7-curl \
-        php7-dom \
-        php7-ftp \
-        php7-gd \
-        php7-mbstring \
-        php7-simplexml \
-        php7-tokenizer \
-        php7-xml \
-        php7-xmlreader \
-        php7-xmlwriter \
+        php83-cli \
+        php83-curl \
+        php83-dom \
+        php83-ftp \
+        php83-gd \
+        php83-mbstring \
+        php83-simplexml \
+        php83-tokenizer \
+        php83-xml \
+        php83-xmlreader \
+        php83-xmlwriter \
         composer && \
     apk del --progress --purge && \
     rm -rf /var/cache/apk/*


### PR DESCRIPTION
Update the PHP Version also in Dockerfile

The changes in #250 broke the docker build:
```
#8 0.459 Your requirements could not be resolved to an installable set of packages.
#8 0.459 
#8 0.459   Problem 1
#8 0.459     - This package requires php ^8.2 but your PHP version (7.3.33) does not satisfy that requirement.
```
