### PR TITLE
Docker: Upgrade to Alpine 3.23 and PHP 8.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,7 @@ VOLUME [ "/data" ]
 RUN set -xe && \
     apk update && apk upgrade && \
     apk add --no-cache --virtual=run-deps \
-        # for CLI
-        php84-dev \
-        # for carddav2fb
+        php84-cli \
         php84-curl \
         php84-dom \
         php84-ftp \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.23
 LABEL description="Download CardDAV VCards and upload as phonebook to AVM FRITZ!Box"
 
 VOLUME [ "/data" ]
@@ -7,17 +7,19 @@ VOLUME [ "/data" ]
 RUN set -xe && \
     apk update && apk upgrade && \
     apk add --no-cache --virtual=run-deps \
-        php7-cli \
-        php7-curl \
-        php7-dom \
-        php7-ftp \
-        php7-gd \
-        php7-mbstring \
-        php7-simplexml \
-        php7-tokenizer \
-        php7-xml \
-        php7-xmlreader \
-        php7-xmlwriter \
+        # for CLI
+        php84-dev \
+        # for carddav2fb
+        php84-curl \
+        php84-dom \
+        php84-ftp \
+        php84-gd \
+        php84-mbstring \
+        php84-simplexml \
+        php84-tokenizer \
+        php84-xml \
+        php84-xmlreader \
+        php84-xmlwriter \
         composer && \
     apk del --progress --purge && \
     rm -rf /var/cache/apk/*


### PR DESCRIPTION
This PR upgrades the Docker image to
* the latest Alpine 3.23
* the contained PHP 8.4

_PS: Would be great to update [hub.docker.com](https://hub.docker.com/r/andig/carddav2fb) from time to time._